### PR TITLE
Allow fixed-size crops and tag carrying

### DIFF
--- a/inbac/controller.py
+++ b/inbac/controller.py
@@ -1,6 +1,7 @@
 import itertools
 import mimetypes
 import os
+import shutil
 
 from typing import Optional, List, Tuple
 
@@ -182,6 +183,16 @@ class Controller():
                 new_filename),
             self.model.args.image_format,
             quality=self.model.args.image_quality)
+
+        if self.model.args.copy_tag_files:
+            original_filename, _ = os.path.splitext(self.model.images[self.model.current_file])
+            tag_file = os.path.join(self.model.args.input_dir, f"{original_filename}.txt")
+            if os.path.exists(tag_file):
+                target_tag_base, _ = os.path.splitext(new_filename)
+                target_tag_file = os.path.join(self.model.args.output_dir, f"{target_tag_base}.txt")
+                if not os.path.exists(target_tag_file):
+                    shutil.copyfile(tag_file, target_tag_file, follow_symlinks=True)
+
         self.clear_selection_box()
         return True
 

--- a/inbac/model.py
+++ b/inbac/model.py
@@ -13,8 +13,11 @@ class Model():
         self.move_coord: Tuple[int, int] = (0, 0)
         self.displayed_image: Optional[PhotoImage] = None
         self.canvas_image: Optional[Any] = None
+        self.cavnas_image_scaling_ratio: Optional[float] = None
         self.canvas_image_dimensions: Tuple[int, int] = (0, 0)
         self.current_image: Optional[Image] = None
         self.enabled_selection_mode: bool = False
         self.box_selected: bool = False
         self.current_file: int = 0
+        self.selected_fixed_size_index: Optional[int] = None
+        self.selected_fixed_size: Optional[Tuple[int, int]] = None

--- a/inbac/parse_arguments.py
+++ b/inbac/parse_arguments.py
@@ -69,6 +69,11 @@ Left Arrow or Middle Mouse Button - go to previous picture\n"""
         default=[],
         dest='fixed_sizes',
         help="a fixed crop size to use (example: 1920x1080): may be specified multiple times")
+    parser.add_argument(
+        "--copy_tag_files",
+        action="store_true",
+        default=False,
+        help="if set, copy any .txt file with the same basename to the output directory and name it like the crop")
     parser.add_argument("-f", "--image_format",
                         help="define the croped image format")
     parser.add_argument("-q", "--image_quality", type=int,

--- a/inbac/parse_arguments.py
+++ b/inbac/parse_arguments.py
@@ -1,6 +1,23 @@
 import argparse
 
 
+class FixedSizeAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        list_val = getattr(namespace, self.dest, [])
+
+        parts = value.split('x')
+        if len(parts) != 2:
+            raise ValueError(f"fixed_size format example: 1024x768. Gotten value '{value}' is invalid")
+        list_val.append((int(parts[0]), int(parts[1])))
+
+        setattr(namespace, self.dest, list_val)
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -46,6 +63,12 @@ Left Arrow or Middle Mouse Button - go to previous picture\n"""
         default=[
             800,
             600])
+    parser.add_argument(
+        "--fixed_size",
+        action=FixedSizeAction,
+        default=[],
+        dest='fixed_sizes',
+        help="a fixed crop size to use (example: 1920x1080): may be specified multiple times")
     parser.add_argument("-f", "--image_format",
                         help="define the croped image format")
     parser.add_argument("-q", "--image_quality", type=int,

--- a/inbac/view.py
+++ b/inbac/view.py
@@ -26,6 +26,7 @@ class View():
         self.master.bind('x', self.save)
         self.master.bind('c', self.rotate_image)
         self.master.bind('r', self.rotate_aspect_ratio)
+        self.master.bind('f', self.cycle_fixed_selection_sizes)
         self.master.bind('<Left>', self.previous_image)
         self.master.bind('<Right>', self.next_image)
         self.master.bind('<ButtonPress-3>', self.next_image)
@@ -264,3 +265,19 @@ class View():
 
     def rotate_aspect_ratio(self, event: Event = None):
         self.controller.rotate_aspect_ratio()
+
+    def cycle_fixed_selection_sizes(self, event: Event = None):
+        model = self.controller.model
+        if len(model.args.fixed_sizes) == 0:
+            return
+
+        if model.selected_fixed_size_index is None:
+            model.selected_fixed_size_index = 0
+        else:
+            model.selected_fixed_size_index += 1
+
+        if model.selected_fixed_size_index == len(model.args.fixed_sizes):
+            model.selected_fixed_size_index = None
+            model.selected_fixed_size = None
+        else:
+            model.selected_fixed_size = model.args.fixed_sizes[model.selected_fixed_size_index]


### PR DESCRIPTION
Hey! You have a lovely little application here. I know this might surprise you, but I think this might be the best free assisted cropping tool on the whole Internet. The best I found, at least.

Assisted cropping like this is about to become extremely important because of the boom in "AI" (deep learning) technologies. Training high quality algorithms requires high quality data sets, and that means nicely uniformly-sized images with carefully defined features.

In this pull request, I add two features (heh heh) which are likely to be useful for rapidly preparing uniform data sets. First, I allow "fixed size" crops. You an specify an arbitrary number of crop dimensions like so:

```
poetry run inbac --fixed_size 512x512 --fixed_size 512x768
```

When you do that, pressing `f` in the crop view will cycle through the list of fixed dimensions (and the default behavior). When a fixed crop is being used, dragging the mouse will drag the upper left hand corner a constant-size box; I hope you find this intuitive and efficient.

The second feature is to 'carry' tag files. Frequently in machine learning datasets there are "sidecar" files - .txt files named the same as the source image - containing metadata about the images. With this change, each crop gets an identical copy of the tags from the source, speeding up the process of later tagging the crops.

I hope you find this contribution useful, and that your software speeds up all the budding machine learning folks out there!