### PR TITLE
Fix output crops files numbering

### DIFF
--- a/inbac/controller.py
+++ b/inbac/controller.py
@@ -247,15 +247,12 @@ class Controller():
         return (coordinates[0] > selection_box[0] and coordinates[0] < selection_box[2]
                 and coordinates[1] > selection_box[1] and coordinates[1] < selection_box[3])
 
-    @staticmethod
-    def find_available_name(directory: str, filename: str) -> str:
+    def find_available_name(self, directory: str, filename: str) -> str:
         name, extension = os.path.splitext(filename)
         for num in itertools.count(0):
-            if not os.path.isfile(
-                os.path.join(
-                    directory,
-                    name + "_" + str(num) + extension)):
-                return name + "_" + str(num) + extension
+            cont = name + "_" + str(num) + "." + self.model.args.image_format
+            if not os.path.isfile(os.path.join(directory, cont)):
+                return cont
         raise ValueError("No available name found")
 
     @staticmethod

--- a/inbac/controller.py
+++ b/inbac/controller.py
@@ -182,7 +182,7 @@ class Controller():
         saved_image.save(
             os.path.join(
                 self.model.args.output_dir,
-                new_filename),
+                new_filename + "." + self.model.args.image_format),
             self.model.args.image_format,
             quality=self.model.args.image_quality)
 
@@ -250,16 +250,12 @@ class Controller():
     @staticmethod
     def find_available_name(directory: str, filename: str) -> str:
         name, extension = os.path.splitext(filename)
-        if not os.path.isfile(os.path.join(directory, filename)):
-            return filename
-        for num in itertools.count(2):
+        for num in itertools.count(0):
             if not os.path.isfile(
                 os.path.join(
                     directory,
-                    name +
-                    str(num) +
-                    extension)):
-                return name + str(num) + extension
+                    name + "_" + str(num) + extension)):
+                return name + "_" + str(num) + extension
         raise ValueError("No available name found")
 
     @staticmethod


### PR DESCRIPTION
When program writes second output crop, it misses loses the extension For example
  inbac input output -f png
would produce only one crop for every image in input/.